### PR TITLE
fix: sayfa geçişlerinde 1 den öncesine ve 604 den sonrası açabilmesi problemi

### DIFF
--- a/components/quran/quran-navigation.tsx
+++ b/components/quran/quran-navigation.tsx
@@ -168,7 +168,7 @@ export function QuranNavigation({ currentPage }: QuranNavigationProps) {
           disabled={currentPage <= 1}
           className="flex-none border-2 border-border"
         >
-          <Link href={pageHref(currentPage - 1)}>
+          <Link href={pageHref(currentPage - 1)} className={`${currentPage <= 1 ? 'pointer-events-none opacity-40' : ''}`}>
             <ChevronLeft className="h-4 w-4" />
             <span className="ml-1 hidden xs:inline">{t("quran.previous")}</span>
           </Link>
@@ -187,7 +187,7 @@ export function QuranNavigation({ currentPage }: QuranNavigationProps) {
           disabled={currentPage >= 604}
           className="flex-none border-2 border-border"
         >
-          <Link href={pageHref(currentPage + 1)}>
+          <Link href={pageHref(currentPage + 1)} className={`${currentPage >= 604 ? 'pointer-events-none opacity-40' : ''}`}>
             <span className="mr-1 hidden xs:inline">{t("quran.next")}</span>
             <ChevronRight className="h-4 w-4" />
           </Link>


### PR DESCRIPTION

Merhaba;

Sayfa geçişlerinde 1’den önceki ve 604’ten sonraki sayfalara geçiş yapılabiliyordu. 1. sayfada “Önceki” ve 604. sayfada “Sonraki” butonuna tıklanamayacak şekilde style ında düzenlemesi yapıldı. Bu problem giderildi.

Problemli Hali:

https://github.com/user-attachments/assets/f483e5b0-ed5a-4c3d-acba-365be3dd3ef4



Düzeltilmiş Hali:

https://github.com/user-attachments/assets/83ef239f-b86d-46ab-bf37-087c672e37ff


